### PR TITLE
Fixes sax-js bug 233 (processing instruction ending with "?")

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -1263,6 +1263,8 @@
             })
             parser.procInstName = parser.procInstBody = ''
             parser.state = S.TEXT
+          } else if (c === '?') {
+            parser.procInstBody += '?'
           } else {
             parser.procInstBody += '?' + c
             parser.state = S.PROC_INST_BODY

--- a/test/issue-233.js
+++ b/test/issue-233.js
@@ -1,0 +1,10 @@
+require(__dirname).test({
+  xml: '<r><?Is this legal XML??><?Is this legal XML? ?></r>',
+  expect: [
+    ['opentagstart', {'name': 'R', 'attributes': {}}],
+    ['opentag', {'name': 'R', 'attributes': {}, 'isSelfClosing': false}],
+    [ 'processinginstruction', { name: 'Is', body: 'this legal XML?' } ],
+    [ 'processinginstruction', { name: 'Is', body: 'this legal XML? ' } ],
+    ['closetag', 'R']
+  ]
+})


### PR DESCRIPTION
This is the fix for https://github.com/isaacs/sax-js/issues/233 , but fixed in our fork of the https://github.com/isaacs/sax-js repo since that repo doesn't seem to be getting any attention.  The equivalent PR in that repo is https://github.com/isaacs/sax-js/pull/234 - I've just copied the code here.